### PR TITLE
Add Stripe backend and Discord bot example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+PORT=3000
+PUBLIC_URL=http://localhost:3000
+STRIPE_SECRET_KEY=sk_test_yourkey
+STRIPE_WEBHOOK_SECRET=whsec_yoursecret
+MONGODB_URI=mongodb://localhost:27017/payments
+BACKEND_URL=http://localhost:3000
+DISCORD_TOKEN=your_bot_token

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # PrinceDevelopment
+
+This repository provides a simple example of an Express backend integrated with Stripe and a small Discord bot. The backend exposes endpoints to create a checkout session and handle Stripe webhooks. The Discord bot sends an embed with a button that redirects the user to the checkout URL returned from the backend.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in the required environment variables.
+2. Install dependencies with `npm install` (requires internet access).
+3. Start the backend with `node backend/index.js`.
+4. Start the Discord bot with `node bot/index.js`.
+
+## Environment variables
+
+```
+PORT=3000
+PUBLIC_URL=http://localhost:3000
+STRIPE_SECRET_KEY=your_stripe_secret
+STRIPE_WEBHOOK_SECRET=your_webhook_secret
+MONGODB_URI=mongodb://localhost:27017/payments
+BACKEND_URL=http://localhost:3000
+DISCORD_TOKEN=your_bot_token
+```

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,85 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import Stripe from 'stripe';
+import dotenv from 'dotenv';
+
+
+dotenv.config();
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+
+const app = express();
+app.use(express.json());
+
+mongoose.connect(process.env.MONGODB_URI, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
+
+const paymentSchema = new mongoose.Schema({
+  userId: String,
+  title: String,
+  amount: Number,
+  stripeSessionId: String,
+  createdAt: { type: Date, default: Date.now }
+});
+
+const Payment = mongoose.model('Payment', paymentSchema, 'payments');
+
+app.post('/create-checkout-session', async (req, res) => {
+  const { title, amount, userId } = req.body;
+  if (!title || !amount || !userId) {
+    return res.status(400).json({ error: 'Missing required fields' });
+  }
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            product_data: { name: title },
+            unit_amount: Math.round(amount * 100),
+          },
+          quantity: 1,
+        },
+      ],
+      metadata: { userId, title },
+      success_url: `${process.env.PUBLIC_URL}/success`,
+      cancel_url: `${process.env.PUBLIC_URL}/cancel`,
+    });
+    res.json({ url: session.url });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to create session' });
+  }
+});
+
+app.post('/webhook', express.raw({ type: 'application/json' }), (req, res) => {
+  const sig = req.headers['stripe-signature'];
+
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(req.body, sig, process.env.STRIPE_WEBHOOK_SECRET);
+  } catch (err) {
+    console.error('Webhook signature verification failed:', err.message);
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object;
+    const payment = new Payment({
+      userId: session.metadata.userId,
+      title: session.metadata.title || 'Unknown',
+      amount: session.amount_total / 100,
+      stripeSessionId: session.id,
+    });
+    payment.save().catch(console.error);
+  }
+
+  res.json({ received: true });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,0 +1,50 @@
+import { Client, GatewayIntentBits, Partials, EmbedBuilder, ButtonBuilder, ButtonStyle, ActionRowBuilder } from 'discord.js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const client = new Client({
+  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent],
+  partials: [Partials.Channel]
+});
+
+client.once('ready', () => {
+  console.log(`Logged in as ${client.user.tag}`);
+});
+
+client.on('messageCreate', async (message) => {
+  if (message.author.bot) return;
+  if (!message.content.startsWith('!list')) return;
+
+  const title = 'Example Item';
+  const amount = 5; // USD
+
+  try {
+    const response = await fetch(`${process.env.BACKEND_URL}/create-checkout-session`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, amount, userId: message.author.id })
+    });
+
+    const data = await response.json();
+    if (!data.url) throw new Error('No checkout URL returned');
+
+    const embed = new EmbedBuilder()
+      .setTitle(title)
+      .setDescription(`Price: $${amount}`);
+
+    const button = new ButtonBuilder()
+      .setLabel('Buy Now')
+      .setStyle(ButtonStyle.Link)
+      .setURL(data.url);
+
+    const row = new ActionRowBuilder().addComponents(button);
+
+    await message.reply({ embeds: [embed], components: [row] });
+  } catch (err) {
+    console.error(err);
+    await message.reply('Failed to create checkout session.');
+  }
+});
+
+client.login(process.env.DISCORD_TOKEN);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "princedevelopment",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "discord.js": "^14.13.0",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "mongoose": "^7.5.0",
+    "stripe": "^13.0.0",
+    "body-parser": "^1.20.2"
+  }
+}


### PR DESCRIPTION
## Summary
- set up Node project
- add Express backend with Stripe checkout and webhook handling
- add simple Discord bot that provides a buy button
- document environment variables and setup
- provide example `.env` file

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6869c648eaac83309f9fc556590561fd